### PR TITLE
1.14.0 - Added Stop, Pause, & Destroy to the AnimChain object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+sourcemap.json

--- a/AnimNation/AnimChain.luau
+++ b/AnimNation/AnimChain.luau
@@ -12,6 +12,9 @@ export type AnimChainImpl = {
 	new: (animators: { Spring | Tween }?) -> AnimChain,
 	AndThen: (AnimChain, callback: () -> ()) -> AnimChain,
 	Await: (AnimChain) -> AnimChain,
+	Resume: (AnimChain) -> AnimChain,
+	Pause: (AnimChain) -> AnimChain,
+	Destroy: (AnimChain) -> (),
 
 	-- Private members
 
@@ -27,6 +30,7 @@ export type AnimChain = typeof(setmetatable(
 		_animators: { Spring | Tween },
 		_callbackQueue: { () -> () },
 		_processingQueue: boolean,
+		_destroyed: boolean,
 	},
 	{} :: AnimChainImpl
 ))
@@ -59,15 +63,20 @@ function AnimChain:_processCallbackQueue()
 end
 
 function AnimChain:_waitForAnimationsCompleted()
+	if self._destroyed then
+		return
+	end
+
 	for _, animator: Spring | Tween in ipairs(self._animators) do
 		if typeof(animator) == "table" then -- Spring
-			while animator:IsAnimating(0.01) do
+			while animator:IsAnimating(0.01) and not self._destroyed do
 				task.wait()
 			end
 		elseif typeof(animator) == "Instance" then -- Tween
 			while
 				animator.PlaybackState ~= Enum.PlaybackState.Completed
 				and animator.PlaybackState ~= Enum.PlaybackState.Cancelled
+				and not self._destroyed
 			do
 				animator:GetPropertyChangedSignal("PlaybackState"):Wait()
 			end
@@ -83,10 +92,18 @@ end
 	@return AnimChain -- The current AnimChain object
 ]=]
 function AnimChain:AndThen(callback: () -> ()): AnimChain
+	if self._destroyed then
+		return self
+	end
+
 	task.spawn(function()
 		table.insert(self._callbackQueue, callback)
 
 		self:_waitForAnimationsCompleted()
+
+		if self._destroyed then
+			return self
+		end
 
 		self:_processCallbackQueue()
 	end)
@@ -110,6 +127,10 @@ function AnimChain:Await(): AnimChain
 
 	self:_waitForAnimationsCompleted()
 
+	if self._destroyed then
+		return self
+	end
+
 	task.spawn(self._processCallbackQueue, self)
 
 	while locked do
@@ -117,6 +138,63 @@ function AnimChain:Await(): AnimChain
 	end
 
 	return self :: AnimChain
+end
+
+--[=[
+	Pauses all animators.
+
+	@return AnimChain - The current AnimChain object.
+]=]
+function AnimChain:Pause(): AnimChain
+	for _, animator in ipairs(self._animators) do
+		animator:Pause()
+	end
+
+	return self :: AnimChain
+end
+
+--[=[
+	Resumes all animators.
+
+	@return AnimChain - The current AnimChain object
+]=]
+function AnimChain:Resume(): AnimChain
+	for _, animator in ipairs(self._animators) do
+		if typeof(animator) == "Instance" and animator:IsA("Tween") then
+			animator:Play()
+		elseif typeof(animator) == "table" then
+			animator:Resume()
+		end
+	end
+
+	return self :: AnimChain
+end
+
+--[=[
+	Destroys the AnimChain object.
+]=]
+function AnimChain:Destroy()
+	if self._destroyed then
+		return
+	end
+
+	self._destroyed = true
+
+	for _, animator in ipairs(self._animators) do
+		if typeof(animator) == "Instance" and animator:IsA("Tween") then
+			animator:Destroy()
+		elseif typeof(animator) == "table" then
+			animator:Pause()
+			animator:Destroy()
+		end
+	end
+
+	table.clear(self._animators)
+	table.clear(self._callbackQueue)
+
+	for k in pairs(self) do
+		self[k] = nil
+	end
 end
 
 --[=[

--- a/AnimNation/Spring.luau
+++ b/AnimNation/Spring.luau
@@ -31,6 +31,8 @@ export type SpringImpl = {
 
 	new: (initial: Springable, clock: ((number) -> ())?) -> Spring,
 	Bind: (self: Spring, label: string, callback: (position: Springable, velocity: Springable) -> ()) -> (),
+	Pause: (self: Spring) -> (),
+	Resume: (self: Spring) -> (),
 	Destroy: (self: Spring) -> (),
 	Disconnect: (self: Spring) -> (),
 	Impulse: (self: Spring, force: Springable) -> (),
@@ -77,6 +79,8 @@ export type Spring = typeof(setmetatable(
 		_time0: number,
 		_damper: number,
 		_speed: number,
+		_paused: boolean,
+		_pauseTime: number,
 		_updating: boolean,
 		_isBound: boolean,
 		_callbacks: { [string]: (position: Springable, velocity: Springable) -> () },
@@ -386,6 +390,10 @@ function Spring:__newindex(index: string, value: any)
 end
 
 function Spring:_positionVelocity(now: number)
+	if self._paused then
+		now = self._pauseTime
+	end
+
 	local damper = self._damper
 	local speed = self._speed
 	local t = speed * (now - self._time0)
@@ -427,11 +435,15 @@ function Spring:_updateCallbacks()
 
 	task.spawn(function()
 		while self._isBound and self:IsAnimating() do
-			for _, callback in self._callbacks do
-				task.spawn(callback, self.Position, self.Velocity)
+			if not self._paused then
+				for _, callback in self._callbacks do
+					task.spawn(callback, self.Position, self.Velocity)
+				end
 			end
+
 			task.wait()
 		end
+
 		-- One more pass because callbacks may not have been called with the
 		-- final values (happens frequently during low frame rates)
 		for _, callback in self._callbacks do
@@ -567,6 +579,32 @@ function Spring:IsAnimating(epsilon: number?): (boolean, Springable)
 end
 
 --[=[
+	Pauses the spring.
+]=]
+function Spring:Pause()
+	if self._paused then
+		return
+	end
+
+	self._paused = true
+	self._pauseTime = self._clock()
+end
+
+--[=[
+	Resumes the spring.
+]=]
+function Spring:Resume()
+	if not self._paused then
+		return
+	end
+
+	local pausedDuration = self._clock() - self._pauseTime
+
+	self._time0 += pausedDuration
+	self._paused = false
+end
+
+--[=[
 	Cleans up any bindings.
 ]=]
 function Spring:Destroy()
@@ -612,6 +650,8 @@ function Spring.new(initial: Springable, clock: (() -> number)?)
 	self._speed = 1
 	self._updating = false
 	self._isBound = false
+	self._paused = false
+	self._pauseTime = 0
 	self._callbacks = {}
 
 	return setmetatable(self, Spring)

--- a/AnimNation/Spring.luau
+++ b/AnimNation/Spring.luau
@@ -1,5 +1,5 @@
 --[[ File Info
-	Author(s): ChiefWildin, TactBacon, Quenty
+	Author(s): ChiefWildin, TactBacon, Quenty, MarsSquirrel
 ]]
 
 -- Types

--- a/AnimNation/init.luau
+++ b/AnimNation/init.luau
@@ -1,6 +1,6 @@
 --[[ File Info
 	Author(s): ChiefWildin
-	Version: 1.13.1
+	Version: 1.13.2
 ]]
 
 -- Services

--- a/AnimNation/init.luau
+++ b/AnimNation/init.luau
@@ -1,6 +1,6 @@
 --[[ File Info
 	Author(s): ChiefWildin
-	Version: 1.13.2
+	Version: 1.14.0
 ]]
 
 -- Services

--- a/selene.toml
+++ b/selene.toml
@@ -1,0 +1,1 @@
+std="roblox"

--- a/wally.toml
+++ b/wally.toml
@@ -9,7 +9,7 @@ description = "An animation library that enables quick one-shot style animations
 
 # Versions follow Semantic Versioning.
 # https://semver.org/
-version = "1.13.1"
+version = "1.14.0"
 
 # Contains an SPDX License Expression.
 # Licenses are required for publishing code to public registries.


### PR DESCRIPTION
**Summary**
I've been using AnimChain for a long time now, and one feature I've always wanted is support for garbage collection. This PR adds that support. Now, AnimChain objects can be properly paused, resumed, and destroyed, automatically integrated into packages such as [Janitor](https://howmanysmall.github.io/Janitor/) & [Maid](https://sleitnick.github.io/AeroGameFramework/module_docs/shared/maid/).

Notes:
* The method is called `:Resume()`, because AnimNation already automatically plays all animators upon creation. I'm not opposed to changing it to play or creating an alias, but I didn't want to confuse developers.

Updates:
* Selene linting
* Ignored Rojo's `sourcemap.json`
* Springs now support `:Pause()` & `:Resume()` methods
* AnimChain supports `:Pause()`, `:Resume()`, & `:Destroy()` methods.